### PR TITLE
Added parsing exception analysis.

### DIFF
--- a/src/main/java/org/openrewrite/FindParseFailureAnalysis.java
+++ b/src/main/java/org/openrewrite/FindParseFailureAnalysis.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.table.ParseFailureAnalysis;
+
+import java.util.*;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class FindParseFailureAnalysis extends ScanningRecipe<FindParseFailureAnalysis.Accumulator> {
+    transient ParseFailureAnalysis report = new ParseFailureAnalysis(this);
+
+    @Option(displayName = "Mark source files",
+            description = "Adds a `SearchResult` marker to LST elements that resulted in a parser exception.",
+            required = false)
+    @Nullable
+    Boolean markFailures;
+
+    @Option(displayName = "`ParseExceptionAnalysis.errorName`",
+            description = "Limits the marked results to a specific node or exception name.",
+            required = false)
+    @Nullable
+    String errorName;
+
+    @Override
+    public String getDisplayName() {
+        return "Parser exception report";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Collects a count of ParseExceptionResults per `Tree`. Optionally, marks each `J.Unknown` to view the unparsed code.";
+    }
+
+    @Data
+    static class Accumulator {
+        Map<String, Map<String, Integer>> counts = new HashMap<>();
+        List<SourceFile> results = new ArrayList<>();
+    }
+
+    @Override
+    public Accumulator getInitialValue(ExecutionContext ctx) {
+        return new Accumulator();
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(Accumulator acc) {
+        return new TreeVisitor<Tree, ExecutionContext>() {
+            @Override
+            public Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+                if (!(tree instanceof SourceFile)) {
+                    return tree;
+                }
+
+                SourceFile s = (SourceFile) tree;
+                if (Boolean.TRUE.equals(markFailures)) {
+                    acc.results.add((SourceFile) new AnalysisVisitor(s, acc.getCounts(), markFailures, errorName).visit(s, ctx));
+                } else {
+                    new AnalysisVisitor(s, acc.getCounts(), markFailures, errorName).visit(s, ctx);
+                }
+                return s;
+            }
+        };
+    }
+
+    @Override
+    public Collection<? extends SourceFile> generate(Accumulator acc, ExecutionContext ctx) {
+        for (Map.Entry<String, Map<String, Integer>> fileExtensionEntries : acc.getCounts().entrySet()) {
+            for (Map.Entry<String, Integer> nodeTypeCounts : fileExtensionEntries.getValue().entrySet()) {
+                report.insertRow(ctx, new ParseFailureAnalysis.Row(fileExtensionEntries.getKey(), nodeTypeCounts.getKey(), nodeTypeCounts.getValue()));
+            }
+        }
+        return acc.results;
+    }
+
+    private static class AnalysisVisitor extends TreeVisitor<Tree, ExecutionContext> {
+        private final Map<String, Map<String, Integer>> counts;
+        private final Set<String> ids = new HashSet<>();
+        private final boolean markFailures;
+
+        @Nullable
+        private final String markNodeType;
+
+        private final String extension;
+
+        public AnalysisVisitor(SourceFile source, Map<String, Map<String, Integer>> counts, @Nullable Boolean markFailures, @Nullable String markNodeType) {
+            this.counts = counts;
+            this.markFailures = Boolean.TRUE.equals(markFailures);
+            this.markNodeType = markNodeType;
+
+            this.extension = source.getSourcePath().toString().substring(source.getSourcePath().toString().lastIndexOf(".") + 1);
+        }
+
+        @Nullable
+        @Override
+        public Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+            if (tree == null) {
+                return null;
+            }
+
+            Tree t = super.visit(tree, ctx);
+            if (t != null) {
+                ParseExceptionResult result = t.getMarkers().findFirst(ParseExceptionResult.class).orElse(null);
+                if (result != null) {
+                    if (ParseFailureAnalysis.containsMessage(result.getMessage())) {
+                        String name = ParseFailureAnalysis.getErrorName(result.getMessage());
+                        if (markFailures) {
+                            if ((markNodeType == null || markNodeType.equals(name))) {
+                                if (ids.add(result.getId().toString())) {
+                                    t = SearchResult.found(t);
+                                }
+                            }
+                        }
+                        Map<String, Integer> nodeTypeCounts = counts.computeIfAbsent(extension, k -> new HashMap<>());
+                        nodeTypeCounts.merge(name, 1, Integer::sum);
+                    }
+                }
+            }
+            return t;
+        }
+    }
+}

--- a/src/main/java/org/openrewrite/table/ParseFailureAnalysis.java
+++ b/src/main/java/org/openrewrite/table/ParseFailureAnalysis.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.table;
+
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.internal.lang.Nullable;
+
+/**
+ * Aggregate parsing errors by file extension, cause, and count to identify and accelerate fixing parsing errors.
+ */
+public class ParseFailureAnalysis extends DataTable<ParseFailureAnalysis.Row> {
+
+    public ParseFailureAnalysis(Recipe recipe) {
+        super(recipe, "Find and aggregate parsing errors",
+                "Finds and aggregates parsing exceptions to fix the most common issues first.");
+    }
+
+    @Value
+    public static class Row {
+        @Column(displayName = "Source file extension",
+                description = "The file extension of the source.")
+        String fileExtension;
+
+        @Column(displayName = "Exception name or node type",
+                description = "Identifies the cause of a parsing error.")
+        String errorName;
+
+        @Column(displayName = "Error count",
+                description = "A count of the errors by name and file extension.")
+        int exceptionCount;
+    }
+
+    /**
+     * Generate a parsing exception message from a given node type for analysis.
+     * @param errorName A unique name that represents the node type or exception name that caused the parsing exception.
+     * @return analysis message.
+     */
+    public static String getAnalysisMessage(String errorName) {
+        return getAnalysisMessage(errorName, null);
+    }
+
+    /**
+     * Generate a parsing exception message from a given node type for analysis.
+     * @param errorName A unique name that represents the node type that caused the parsing exception.
+     * @param sourceSnippet Optional source snippet to identify where the exception occurred.
+     * @return analysis message.
+     */
+    public static String getAnalysisMessage(String errorName, @Nullable String sourceSnippet) {
+        return "Unable to parse node of type {{" + errorName + (sourceSnippet != null ? "}} at: " + sourceSnippet : "}}");
+    }
+
+    public static boolean containsMessage(String message) {
+        return message.contains("Unable to parse node of type {{");
+    }
+
+    public static String getErrorName(String message) {
+        if (message.contains("{{")) {
+            return message.substring(message.indexOf("{{") + 2, message.indexOf("}}"));
+        } else {
+            return message.substring(0, message.indexOf(":"));
+        }
+    }
+
+    public static String getSourceSnippet(String message) {
+        int start = message.indexOf("}} at: ") + 7;
+        return start > 6 ? message.substring(start) : "";
+    }
+}

--- a/src/test/java/org/openrewrite/table/ParseFailureAnalysisTest.java
+++ b/src/test/java/org/openrewrite/table/ParseFailureAnalysisTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.table;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ParseFailureAnalysisTest {
+
+    @Test
+    void generatesMessage() {
+        String msg = ParseFailureAnalysis.getAnalysisMessage("someNodeType");
+        assertThat(msg).isEqualTo("Unable to parse node of type {{someNodeType}}");
+
+        String msgWithSnipper = ParseFailureAnalysis.getAnalysisMessage("someNodeType", "someSnippet");
+        assertThat(msgWithSnipper).isEqualTo("Unable to parse node of type {{someNodeType}} at: someSnippet");
+    }
+
+    @Test
+    void returnsNodeType() {
+        String msg = ParseFailureAnalysis.getAnalysisMessage("someNodeType");
+        assertThat(ParseFailureAnalysis.getErrorName(msg)).isEqualTo("someNodeType");
+    }
+
+    @Test
+    void returnsSnippet() {
+        String msg = ParseFailureAnalysis.getAnalysisMessage("someNodeType", "someSnippet");
+        assertThat(ParseFailureAnalysis.getSourceSnippet(msg)).isEqualTo("someSnippet");
+    }
+}


### PR DESCRIPTION
## What's changed?
Added parsing failure analysis recipe and data table.

## What's your motivation?
Accelerate fixing parsing issues by collecting counts of errors and enabling unparsed code to be viewed in the SAAS.

## Anything, in particular, you'd like reviewers to focus on?
The recipe and table are just an iteration on `ParseFailures` and `FindParseFailures`. Similar to the differences in LanguageComposition, this recipe aggregates per repository instead of per source file.

The analysis only applies to parsers where the String value of a node will keep the correct cursor position. So, this applies to ANTLR grammars and IntelliJ-based trees. I think the amount of parsing failures captured will depend on the complexity of the language, but we can return a `J.Unknown` in a collection of `Statement`s or `Expression`s.

Each `ParseExceptionAnalysis$Row` is based on the source file extension, an identifier for the parsing error (currently either the name of the exception or node that failed to parse), and a count of the error.

Questions:
When is a recipe or table applicable to rewrite-all vs. rewrite-core?

`FindParseFailures` is located in `rewrite-core`, and I'm curious if I should move `FindParseFailures` to `rewrite-all`, similarly to `LanguageComposition` and distinguish the recipes as `PerFile` and `PerRepository`?

## Anyone you would like to review specifically?
@sambsnyd @jkschneider 