### PR TITLE
Remove dependency on JavaScript

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,6 @@ dependencies {
     implementation("org.openrewrite:rewrite-yaml")
     implementation("org.openrewrite:rewrite-python:$latest")
     implementation("org.openrewrite:rewrite-csharp:$latest")
-    implementation("org.openrewrite:rewrite-javascript:$latest")
 
     testImplementation("org.openrewrite:rewrite-test")
     testRuntimeOnly("org.openrewrite:rewrite-java-17")

--- a/src/main/java/org/openrewrite/LanguageComposition.java
+++ b/src/main/java/org/openrewrite/LanguageComposition.java
@@ -24,7 +24,6 @@ import org.openrewrite.csharp.tree.Cs;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.hcl.tree.Hcl;
 import org.openrewrite.java.tree.J;
-import org.openrewrite.javascript.tree.JS;
 import org.openrewrite.json.tree.Json;
 import org.openrewrite.kotlin.tree.K;
 import org.openrewrite.properties.tree.Properties;
@@ -183,18 +182,6 @@ public class LanguageComposition extends ScanningRecipe<LanguageComposition.Accu
                         perFileReport.insertRow(ctx, new LanguageCompositionPerFile.Row(
                                 s.getSourcePath().toString(),
                                 "C#",
-                                s.getClass().getName(),
-                                genericLineCount,
-                                hasParseFailure));
-                    } else if (s instanceof JS.CompilationUnit) {
-                        Counts javaScriptCounts = acc.getFolderToLanguageToCounts()
-                                .computeIfAbsent(folderPath, k -> new HashMap<>())
-                                .computeIfAbsent("JavaScript", k -> new Counts());
-                        javaScriptCounts.fileCount++;
-                        javaScriptCounts.lineCount += genericLineCount;
-                        perFileReport.insertRow(ctx, new LanguageCompositionPerFile.Row(
-                                s.getSourcePath().toString(),
-                                "JavaScript",
                                 s.getClass().getName(),
                                 genericLineCount,
                                 hasParseFailure));


### PR DESCRIPTION
As OpenRewrite has decided that all new modules will be moved inside openrewrite/rewrite, we now have decided to exclude rewrite-javascript from rewrite-all.
