### PR TITLE
Update FindCallGraphTest to expect void for Kotlin Unit return type

### DIFF
--- a/src/test/java/org/openrewrite/FindCallGraphTest.java
+++ b/src/test/java/org/openrewrite/FindCallGraphTest.java
@@ -382,7 +382,7 @@ class FindCallGraphTest implements RewriteTest {
                 "println",
                 "kotlin.Any",
                 CallGraph.ResourceType.METHOD,
-                "kotlin.Unit"
+                "void"
               )
             )
           ),


### PR DESCRIPTION
## Summary

- CI failure on the [scheduled run](https://github.com/openrewrite/rewrite-all/actions/runs/24472747691): `FindCallGraphTest.companionObject()` asserts `returnType=kotlin.Unit`, but the parser now produces `void`.
- Non-nullable `kotlin.Unit` return types are intentionally mapped to JVM `void` as of rewrite 8.79.4 (openrewrite/rewrite#7364 — "Align Kotlin type model with Java parser output"), so the test expectation is stale.

## Test plan

- [ ] `./gradlew test --tests FindCallGraphTest.companionObject` passes against rewrite 8.79.4+